### PR TITLE
fixed errors in config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 # Paths to book files
 my_book: "goi5.1.bin"
-opp_book: "dec2015_500k.bin"
+opp_book: "dec2015.bin"
 
 # Path to engine file
 engine: "sf_latest"
@@ -16,7 +16,6 @@ max_moves: 25
 
 # Preset lines from which to start practicing
 lines:
-  - start
   # - $hyperaccelerated e4 c5 Nf3 g6 [b]
   - neo-moller [b]
   - najdorf [wb]


### PR DESCRIPTION
Hi!
I changed the default opponent's book to ```dec2015.bin```, as that is how the file is called in the repository (as opposed to ```dec2015_500k.bin```).

Also, I have removed the first line in the ```lines``` section as it causes the script to crash on startup.
Maybe this was intentional to incentivize the user to carefully customize the config file?
